### PR TITLE
Test value before setting "isRestricted" to false

### DIFF
--- a/TLS/src/main/java/de/rub/nds/tlsattacker/tls/config/ConfigHandler.java
+++ b/TLS/src/main/java/de/rub/nds/tlsattacker/tls/config/ConfigHandler.java
@@ -68,7 +68,9 @@ public abstract class ConfigHandler {
 	try {
 	    Field field = Class.forName("javax.crypto.JceSecurity").getDeclaredField("isRestricted");
 	    field.setAccessible(true);
-	    field.set(null, java.lang.Boolean.FALSE);
+	    if (field.getBoolean(null)) {
+	        field.set(null, java.lang.Boolean.FALSE);
+	    }
 	} catch (ClassNotFoundException | IllegalAccessException | IllegalArgumentException | NoSuchFieldException
 		| SecurityException ex) {
 	    throw new ConfigurationException("Not possible to use unrestricted policy in Oracle JDK", ex);

--- a/TLS/src/test/java/de/rub/nds/tlsattacker/tls/misc/UnlimitedStrengthTest.java
+++ b/TLS/src/test/java/de/rub/nds/tlsattacker/tls/misc/UnlimitedStrengthTest.java
@@ -38,7 +38,9 @@ public class UnlimitedStrengthTest {
 	try {
 	    Field field = Class.forName("javax.crypto.JceSecurity").getDeclaredField("isRestricted");
 	    field.setAccessible(true);
-	    field.set(null, java.lang.Boolean.FALSE);
+	    if (field.getBoolean(null)) {
+	        field.set(null, java.lang.Boolean.FALSE);
+	    }
 
 	    Cipher encryptCipher = Cipher.getInstance("AES/CBC/NoPadding", new BouncyCastleProvider());
 	    IvParameterSpec encryptIv = new IvParameterSpec(new byte[16]);


### PR DESCRIPTION
I am using Oracle JDK 1.8.0_112 on OSX 10.11.6. I have the unrestricted policy files installed in the JDK's jre/lib/security folder.

Running ./mvnw clean package gives 2 instances of this exception:
        java.lang.IllegalAccessException: Can not set static final boolean field javax.crypto.JceSecurity.isRestricted to java.lang.Boolean
        at java.lang.reflect.Field.set(Field.java:764)

Since I am using unrestricted policy files already, that call isn't necessary, so I added a check on the current value of the field before attempting to set it (2 instances). ./mvnw clean package completes successfully with these changes.

I would expect the Field.set will still continue to happen for other setups, but have not checked.