### PR TITLE
Fix build error due to missing java.xml.bind

### DIFF
--- a/Transport/pom.xml
+++ b/Transport/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>Utils</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
+        </dependency>
     </dependencies>
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>


### PR DESCRIPTION
java.xml.bind was deprecated in Java 8 and removed in Java 11, which is why Transport fails to build (even when the other issues that currently prevent building are resolved).
Using Jakarta xml as proposed by https://stackoverflow.com/a/52502208/4091513.