### PR TITLE
Bleichenbacher: Add null check for errorType

### DIFF
--- a/Attacks/src/main/java/de/rub/nds/tlsattacker/attacks/impl/BleichenbacherAttacker.java
+++ b/Attacks/src/main/java/de/rub/nds/tlsattacker/attacks/impl/BleichenbacherAttacker.java
@@ -107,7 +107,7 @@ public class BleichenbacherAttacker extends Attacker<BleichenbacherCommandConfig
     @Override
     public Boolean isVulnerable() {
         errorType = getEqualityError();
-        if (errorType != EqualityError.NONE) {
+        if (errorType != null && errorType != EqualityError.NONE) {
             vulnerableType = config.getWorkflowType();
             return true;
         }


### PR DESCRIPTION
When the PublicKey could not be retrieved from Server, `getEqualityError()` returns null. The check in `isVulnerable()` only checks for the `EqualityError.NONE` but not against null values. So when we don't get the PublicKey from the server (e.g. when the cipher the clients requests is not supported by the server), we get the message:

`Could not retrieve PublicKey from Server - is the Server running?`
`Vulnerable:true`

This is a false positive.
This way we get `Vulnerable:false`, which is also not perfect, but reflects it at least a bit better.